### PR TITLE
remove redisDB dependency

### DIFF
--- a/ytsync/manager.go
+++ b/ytsync/manager.go
@@ -256,7 +256,7 @@ func (s SyncManager) Start() error {
 			time.Sleep(5 * time.Minute)
 		}
 		for i, sync := range syncs {
-			SendInfoToSlack("Syncing %s to LBRY! (iteration %d/%d - total session iterations: %d)", sync.LbryChannelName, i, len(syncs), syncCount)
+			SendInfoToSlack("Syncing %s to LBRY! (iteration %d/%d - total session iterations: %d)", sync.LbryChannelName, i+1, len(syncs), syncCount)
 			err := sync.FullCycle()
 			if err != nil {
 				fatalErrors := []string{

--- a/ytsync/manager.go
+++ b/ytsync/manager.go
@@ -136,12 +136,6 @@ const (
 	VideoStatusFailed    = "failed"
 )
 
-type apiVideoStatusResponse struct {
-	Success bool        `json:"success"`
-	Error   null.String `json:"error"`
-	Data    null.String `json:"data"`
-}
-
 func (s SyncManager) MarkVideoStatus(channelID string, videoID string, status string, claimID string, claimName string, failureReason string) error {
 	endpoint := s.ApiURL + "/yt/video_status"
 
@@ -165,7 +159,11 @@ func (s SyncManager) MarkVideoStatus(channelID string, videoID string, status st
 	res, _ := http.PostForm(endpoint, vals)
 	defer res.Body.Close()
 	body, _ := ioutil.ReadAll(res.Body)
-	var response apiVideoStatusResponse
+	var response struct {
+		Success bool        `json:"success"`
+		Error   null.String `json:"error"`
+		Data    null.String `json:"data"`
+	}
 	err := json.Unmarshal(body, &response)
 	if err != nil {
 		return err

--- a/ytsync/manager.go
+++ b/ytsync/manager.go
@@ -122,9 +122,6 @@ func (s SyncManager) setChannelStatus(channelID string, status string) (map[stri
 		return nil, errors.Err(response.Error.String)
 	}
 	if response.Data != nil {
-		if len(response.Data) == 0 {
-			return nil, nil
-		}
 		svs := make(map[string]syncedVideo)
 		for _, v := range response.Data {
 			svs[v.VideoID] = v
@@ -256,7 +253,7 @@ func (s SyncManager) Start() error {
 			time.Sleep(5 * time.Minute)
 		}
 		for i, sync := range syncs {
-			SendInfoToSlack("Syncing %s to LBRY! (iteration %d/%d - total session iterations: %d)", sync.LbryChannelName, i+1, len(syncs), syncCount)
+			SendInfoToSlack("Syncing %s (%s) to LBRY! (iteration %d/%d - total session iterations: %d)", sync.LbryChannelName, sync.YoutubeChannelID, i+1, len(syncs), syncCount)
 			err := sync.FullCycle()
 			if err != nil {
 				fatalErrors := []string{
@@ -270,7 +267,7 @@ func (s SyncManager) Start() error {
 				}
 				SendInfoToSlack("A non fatal error was reported by the sync process. %s\nContinuing...", err.Error())
 			}
-			SendInfoToSlack("Syncing %s reached an end. (Iteration %d/%d - total session iterations: %d))", sync.LbryChannelName, i+1, len(syncs), syncCount)
+			SendInfoToSlack("Syncing %s (%s) reached an end. (Iteration %d/%d - total session iterations: %d))", sync.LbryChannelName, sync.YoutubeChannelID, i+1, len(syncs), syncCount)
 			syncCount++
 			if sync.IsInterrupted() || (s.Limit != 0 && syncCount >= s.Limit) {
 				shouldInterruptLoop = true

--- a/ytsync/manager.go
+++ b/ytsync/manager.go
@@ -270,7 +270,7 @@ func (s SyncManager) Start() error {
 				}
 				SendInfoToSlack("A non fatal error was reported by the sync process. %s\nContinuing...", err.Error())
 			}
-			SendInfoToSlack("Syncing %s reached an end. (Iteration %d/%d - total session iterations: %d))", sync.LbryChannelName, i, len(syncs), syncCount)
+			SendInfoToSlack("Syncing %s reached an end. (Iteration %d/%d - total session iterations: %d))", sync.LbryChannelName, i+1, len(syncs), syncCount)
 			syncCount++
 			if sync.IsInterrupted() || (s.Limit != 0 && syncCount >= s.Limit) {
 				shouldInterruptLoop = true

--- a/ytsync/manager.go
+++ b/ytsync/manager.go
@@ -253,7 +253,7 @@ func (s SyncManager) Start() error {
 			time.Sleep(5 * time.Minute)
 		}
 		for i, sync := range syncs {
-			SendInfoToSlack("Syncing %s (%s) to LBRY! (iteration %d/%d - total session iterations: %d)", sync.LbryChannelName, sync.YoutubeChannelID, i+1, len(syncs), syncCount)
+			SendInfoToSlack("Syncing %s (%s) to LBRY! (iteration %d/%d - total session iterations: %d)", sync.LbryChannelName, sync.YoutubeChannelID, i+1, len(syncs), syncCount+1)
 			err := sync.FullCycle()
 			if err != nil {
 				fatalErrors := []string{
@@ -267,7 +267,7 @@ func (s SyncManager) Start() error {
 				}
 				SendInfoToSlack("A non fatal error was reported by the sync process. %s\nContinuing...", err.Error())
 			}
-			SendInfoToSlack("Syncing %s (%s) reached an end. (Iteration %d/%d - total session iterations: %d))", sync.LbryChannelName, sync.YoutubeChannelID, i+1, len(syncs), syncCount)
+			SendInfoToSlack("Syncing %s (%s) reached an end. (Iteration %d/%d - total session iterations: %d))", sync.LbryChannelName, sync.YoutubeChannelID, i+1, len(syncs), syncCount+1)
 			syncCount++
 			if sync.IsInterrupted() || (s.Limit != 0 && syncCount >= s.Limit) {
 				shouldInterruptLoop = true

--- a/ytsync/setup.go
+++ b/ytsync/setup.go
@@ -44,7 +44,8 @@ func (s *Sync) walletSetup() error {
 		return nil
 	}
 
-	numPublished, err := s.daemon.NumClaimsInChannel(s.LbryChannelName)
+	//numPublished, err := s.daemon.NumClaimsInChannel(s.LbryChannelName)
+	numPublished := uint64(len(s.syncedVideos)) //should we only count published videos? Credits are allocated even for failed ones...
 	if err != nil {
 		return err
 	}
@@ -52,6 +53,11 @@ func (s *Sync) walletSetup() error {
 
 	if float64(numOnSource)-float64(numPublished) > float64(s.Manager.VideosLimit) {
 		numOnSource = uint64(s.Manager.VideosLimit)
+	}
+
+	//TODO: get rid of this as soon as we compute this condition using the database in a more reliable way
+	if numPublished >= numOnSource {
+		return errors.Err("channel is already up to date")
 	}
 	minBalance := (float64(numOnSource)-float64(numPublished))*(publishAmount+0.1) + channelClaimAmount
 	if numPublished > numOnSource {

--- a/ytsync/setup.go
+++ b/ytsync/setup.go
@@ -153,15 +153,15 @@ func (s *Sync) waitForNewBlock() error {
 		return err
 	}
 
-	for status.BlockchainStatus.Blocks == 0 || status.BlockchainStatus.BlocksBehind != 0 {
+	for status.Wallet.Blocks == 0 || status.Wallet.BlocksBehind != 0 {
 		time.Sleep(5 * time.Second)
 		status, err = s.daemon.Status()
 		if err != nil {
 			return err
 		}
 	}
-	currentBlock := status.BlockchainStatus.Blocks
-	for i := 0; status.BlockchainStatus.Blocks <= currentBlock; i++ {
+	currentBlock := status.Wallet.Blocks
+	for i := 0; status.Wallet.Blocks <= currentBlock; i++ {
 		if i%3 == 0 {
 			log.Printf("Waiting for new block (%d)...", currentBlock+1)
 		}

--- a/ytsync/setup.go
+++ b/ytsync/setup.go
@@ -53,12 +53,8 @@ func (s *Sync) walletSetup() error {
 		numOnSource = uint64(s.Manager.VideosLimit)
 	}
 
-	//TODO: get rid of this as soon as we compute this condition using the database in a more reliable way
-	if numPublished >= numOnSource {
-		return nil
-	}
 	minBalance := (float64(numOnSource)-float64(numPublished))*(publishAmount+0.1) + channelClaimAmount
-	if numPublished > numOnSource {
+	if numPublished > numOnSource && balance.LessThan(decimal.NewFromFloat(1)) {
 		SendErrorToSlack("something is going on as we published more videos than those available on source: %d/%d", numPublished, numOnSource)
 		minBalance = 1 //since we ended up in this function it means some juice is still needed
 	}

--- a/ytsync/setup.go
+++ b/ytsync/setup.go
@@ -44,11 +44,7 @@ func (s *Sync) walletSetup() error {
 		return nil
 	}
 
-	//numPublished, err := s.daemon.NumClaimsInChannel(s.LbryChannelName)
 	numPublished := uint64(len(s.syncedVideos)) //should we only count published videos? Credits are allocated even for failed ones...
-	if err != nil {
-		return err
-	}
 	log.Debugf("We already published %d videos", numPublished)
 
 	if float64(numOnSource)-float64(numPublished) > float64(s.Manager.VideosLimit) {

--- a/ytsync/setup.go
+++ b/ytsync/setup.go
@@ -55,7 +55,7 @@ func (s *Sync) walletSetup() error {
 
 	//TODO: get rid of this as soon as we compute this condition using the database in a more reliable way
 	if numPublished >= numOnSource {
-		return errors.Err("channel is already up to date")
+		return nil
 	}
 	minBalance := (float64(numOnSource)-float64(numPublished))*(publishAmount+0.1) + channelClaimAmount
 	if numPublished > numOnSource {
@@ -107,14 +107,6 @@ func (s *Sync) ensureEnoughUTXOs() error {
 		return errors.Err("no response")
 	}
 
-	if !allUTXOsConfirmed(utxolist) {
-		log.Println("Waiting for previous txns to confirm") // happens if you restarted the daemon soon after a previous publish run
-		err := s.waitUntilUTXOsConfirmed()
-		if err != nil {
-			return err
-		}
-	}
-
 	target := 40
 	count := 0
 
@@ -151,6 +143,12 @@ func (s *Sync) ensureEnoughUTXOs() error {
 
 		log.Println("Creating UTXOs and waiting for them to be confirmed")
 		err = s.waitUntilUTXOsConfirmed()
+		if err != nil {
+			return err
+		}
+	} else if !allUTXOsConfirmed(utxolist) {
+		log.Println("Waiting for previous txns to confirm")
+		err := s.waitUntilUTXOsConfirmed()
 		if err != nil {
 			return err
 		}

--- a/ytsync/setup.go
+++ b/ytsync/setup.go
@@ -44,7 +44,9 @@ func (s *Sync) walletSetup() error {
 		return nil
 	}
 
+	s.videosMapMux.Lock()
 	numPublished := uint64(len(s.syncedVideos)) //should we only count published videos? Credits are allocated even for failed ones...
+	s.videosMapMux.Unlock()
 	log.Debugf("We already published %d videos", numPublished)
 
 	if float64(numOnSource)-float64(numPublished) > float64(s.Manager.VideosLimit) {

--- a/ytsync/sources/ucbVideo.go
+++ b/ytsync/sources/ucbVideo.go
@@ -170,25 +170,23 @@ func (v ucbVideo) saveThumbnail() error {
 	return err
 }
 
-func (v ucbVideo) publish(daemon *jsonrpc.Client, claimAddress string, amount float64, channelName string) (*SyncSummary, error) {
+func (v ucbVideo) publish(daemon *jsonrpc.Client, claimAddress string, amount float64, channelID string) (*SyncSummary, error) {
 	options := jsonrpc.PublishOptions{
-		Title:        &v.title,
-		Author:       strPtr("UC Berkeley"),
-		Description:  strPtr(v.getAbbrevDescription()),
-		Language:     strPtr("en"),
-		ClaimAddress: &claimAddress,
-		Thumbnail:    strPtr("https://berk.ninja/thumbnails/" + v.id),
-		License:      strPtr("see description"),
-	}
-
-	if channelName != "" {
-		options.ChannelName = &channelName
+		Title:         &v.title,
+		Author:        strPtr("UC Berkeley"),
+		Description:   strPtr(v.getAbbrevDescription()),
+		Language:      strPtr("en"),
+		ClaimAddress:  &claimAddress,
+		Thumbnail:     strPtr("https://berk.ninja/thumbnails/" + v.id),
+		License:       strPtr("see description"),
+		ChannelID:     &channelID,
+		ChangeAddress: &claimAddress,
 	}
 
 	return publishAndRetryExistingNames(daemon, v.title, v.getFilename(), amount, options)
 }
 
-func (v ucbVideo) Sync(daemon *jsonrpc.Client, claimAddress string, amount float64, channelName string, maxVideoSize int) (*SyncSummary, error) {
+func (v ucbVideo) Sync(daemon *jsonrpc.Client, claimAddress string, amount float64, channelID string, maxVideoSize int) (*SyncSummary, error) {
 	//download and thumbnail can be done in parallel
 	err := v.download()
 	if err != nil {
@@ -202,7 +200,7 @@ func (v ucbVideo) Sync(daemon *jsonrpc.Client, claimAddress string, amount float
 	//}
 	//log.Debugln("Created thumbnail for " + v.id)
 
-	summary, err := v.publish(daemon, claimAddress, amount, channelName)
+	summary, err := v.publish(daemon, claimAddress, amount, channelID)
 	if err != nil {
 		return nil, errors.Prefix("publish error", err)
 	}

--- a/ytsync/sources/youtubeVideo.go
+++ b/ytsync/sources/youtubeVideo.go
@@ -66,7 +66,7 @@ func (v YoutubeVideo) getFilename() string {
 
 	name := chunks[0]
 	if len(name) > maxLen {
-		return name[:maxLen]
+		name = name[:maxLen]
 	}
 
 	for _, chunk := range chunks[1:] {

--- a/ytsync/ytsync.go
+++ b/ytsync/ytsync.go
@@ -132,7 +132,6 @@ func (s *Sync) FullCycle() (e error) {
 			//conditions for which a channel shouldn't be marked as failed
 			noFailConditions := []string{
 				"this youtube channel is being managed by another server",
-				"channel is already up to date",
 			}
 			if util.SubstringInSlice(e.Error(), noFailConditions) {
 				return

--- a/ytsync/ytsync.go
+++ b/ytsync/ytsync.go
@@ -316,6 +316,7 @@ func (s *Sync) startWorker(workerNum int) {
 					"no space left on device",
 					"NotEnoughFunds",
 					"Cannot publish using channel",
+					"more than 90% of the space has been used.",
 				}
 				if util.SubstringInSlice(err.Error(), fatalErrors) || s.StopOnError {
 					s.grp.Stop()
@@ -545,6 +546,10 @@ func (s *Sync) processVideo(v video) (err error) {
 	if v.PlaylistPosition() > s.Manager.VideosLimit {
 		log.Println(v.ID() + " is old: skipping")
 		return nil
+	}
+	err = s.Manager.checkUsedSpace()
+	if err != nil {
+		return err
 	}
 	summary, err := v.Sync(s.daemon, s.claimAddress, publishAmount, s.lbryChannelID, s.Manager.MaxVideoSize)
 	if err != nil {


### PR DESCRIPTION
This PR aims at removing the local redisdb dependency that makes it impossible to redistribute work across different servers.

Further work has been put in, here's a summary:
- Use channel IDs while publishing instead of channel names
- Rename API endpoints and associated functions
- Fix indexes in information sent to slack (those +1s that you see in the loop)
- Slightly changed the way the number of "published" claims is counted (making use of the new synced videos list)
- Add 5% slack on UTXOs to avoid waiting a full block even if just a few transactions were made
- Speed up startup by eliminating unnecessary block waits
- Remove waiting for UTXOs by listing UTXOs (instead we just wait for a new block)
- Small bug fixes