### PR TITLE
Fix dht find value and updates from latest protocol changes

### DIFF
--- a/dht/config.go
+++ b/dht/config.go
@@ -17,7 +17,7 @@ const (
 
 	// TODO: all these constants should be defaults, and should be used to set values in the standard Config. then the code should use values in the config
 	// TODO: alternatively, have a global Config for constants. at least that way tests can modify the values
-	alpha           = 3             // this is the constant alpha in the spec
+	alpha           = 5             // this is the constant alpha in the spec
 	bucketSize      = 8             // this is the constant k in the spec
 	nodeIDLength    = bits.NumBytes // bytes. this is the constant B in the spec
 	messageIDLength = 20            // bytes.

--- a/dht/contact.go
+++ b/dht/contact.go
@@ -2,6 +2,7 @@ package dht
 
 import (
 	"bytes"
+	"encoding/json"
 	"net"
 	"sort"
 	"strconv"
@@ -39,6 +40,20 @@ func (c Contact) String() string {
 		str += "(" + strconv.Itoa(c.PeerPort) + ")"
 	}
 	return str
+}
+
+func (c Contact) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		ID string
+		IP string
+		Port int
+		PeerPort int
+	}{
+		ID: c.ID.Hex(),
+		IP: c.IP.String(),
+		Port: c.Port,
+		PeerPort: c.PeerPort,
+	})
 }
 
 // MarshalCompact returns a compact byteslice representation of the contact

--- a/dht/contact.go
+++ b/dht/contact.go
@@ -44,14 +44,14 @@ func (c Contact) String() string {
 
 func (c Contact) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		ID string
-		IP string
-		Port int
+		ID       string
+		IP       string
+		Port     int
 		PeerPort int
 	}{
-		ID: c.ID.Hex(),
-		IP: c.IP.String(),
-		Port: c.Port,
+		ID:       c.ID.Hex(),
+		IP:       c.IP.String(),
+		Port:     c.Port,
 		PeerPort: c.PeerPort,
 	})
 }

--- a/dht/rpc.go
+++ b/dht/rpc.go
@@ -102,7 +102,7 @@ type RpcIterativeFindValueArgs struct {
 type RpcIterativeFindValueResult struct {
 	Contacts   []Contact
 	FoundValue bool
-	Values      []Contact
+	Values     []Contact
 }
 
 func (rpc *rpcReceiver) IterativeFindValue(r *http.Request, args *RpcIterativeFindValueArgs, result *RpcIterativeFindValueResult) error {

--- a/dht/rpc.go
+++ b/dht/rpc.go
@@ -102,6 +102,7 @@ type RpcIterativeFindValueArgs struct {
 type RpcIterativeFindValueResult struct {
 	Contacts   []Contact
 	FoundValue bool
+	Values      []Contact
 }
 
 func (rpc *rpcReceiver) IterativeFindValue(r *http.Request, args *RpcIterativeFindValueArgs, result *RpcIterativeFindValueResult) error {
@@ -109,12 +110,19 @@ func (rpc *rpcReceiver) IterativeFindValue(r *http.Request, args *RpcIterativeFi
 	if err != nil {
 		return err
 	}
-	foundContacts, found, err := FindContacts(rpc.dht.node, key, false, nil)
+	foundContacts, found, err := FindContacts(rpc.dht.node, key, true, nil)
 	if err != nil {
 		return err
 	}
 	result.Contacts = foundContacts
 	result.FoundValue = found
+	if found {
+		for _, contact := range foundContacts {
+			if contact.PeerPort > 0 {
+				result.Values = append(result.Values, contact)
+			}
+		}
+	}
 	return nil
 }
 

--- a/extras/util/strings.go
+++ b/extras/util/strings.go
@@ -21,6 +21,7 @@ func NormalizeName(s string) string {
 	c := cases.Fold()
 	return c.String(norm.NFD.String(s))
 }
+
 // ReverseBytesInPlace reverse the bytes. thanks, Satoshi 😒
 func ReverseBytesInPlace(s []byte) {
 	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {


### PR DESCRIPTION
* increase alpha to 5
* parse page (even though paging isn't implemented)
* always parse findValue result instead of an alternative to contacts
* improve RPC contact representation to show bytes as hex instead of numbers
* RPC IterativeFindValue now really does use FindValue and shows the result

this makes find value work again and it is pretty fast!